### PR TITLE
Fix issues when using `lazy var` as `swift_declaration_strategy`

### DIFF
--- a/lib/arkana/helpers/swift_template_helper.rb
+++ b/lib/arkana/helpers/swift_template_helper.rb
@@ -9,4 +9,12 @@ module SwiftTemplateHelper
     else raise "Unknown variable type '#{type}' received.'"
     end
   end
+
+  def self.protocol_getter(declaration_strategy)
+    case declaration_strategy
+    when "lazy var" then "mutating get"
+    when "var", "let" then "get"
+    else raise "Unknown declaration strategy '#{declaration_strategy}' received.'"
+    end
+  end
 end

--- a/lib/arkana/templates/arkana_protocol.swift.erb
+++ b/lib/arkana/templates/arkana_protocol.swift.erb
@@ -4,12 +4,12 @@ import Foundation
 
 public protocol <%= @namespace %>GlobalProtocol {
 <% for secret in @global_secrets %>
-    var <%= secret.protocol_key.camel_case %>: <%= SwiftTemplateHelper.swift_type(secret.type) %> { get }
+    var <%= secret.protocol_key.camel_case %>: <%= SwiftTemplateHelper.swift_type(secret.type) %> { <%= SwiftTemplateHelper.protocol_getter(@swift_declaration_strategy) %> }
 <% end %>
 }
 
 public protocol <%= @namespace %>EnvironmentProtocol {
 <% for secret in @environment_secrets.uniq(&:protocol_key) %>
-    var <%= secret.protocol_key.camel_case %>: <%= SwiftTemplateHelper.swift_type(secret.type) %> { get }
+    var <%= secret.protocol_key.camel_case %>: <%= SwiftTemplateHelper.swift_type(secret.type) %> { <%= SwiftTemplateHelper.protocol_getter(@swift_declaration_strategy) %> }
 <% end %>
 }

--- a/lib/arkana/templates/package.swift.erb
+++ b/lib/arkana/templates/package.swift.erb
@@ -25,12 +25,12 @@ let package = Package(
             dependencies: ["<%= @import_name %>Interfaces"],
             path: "Sources"
         ),
-        <% if @should_generate_unit_tests %>
+<% if @should_generate_unit_tests %>
         .testTarget(
             name: "<%= @import_name %>Tests",
             dependencies: ["<%= @import_name %>"],
             path: "Tests"
         ),
-        <% end %>
+<% end %>
     ]
 )

--- a/spec/fixtures/arkana-empty-environment-secrets-fixture.yml
+++ b/spec/fixtures/arkana-empty-environment-secrets-fixture.yml
@@ -5,7 +5,7 @@ result_path: 'MySecrets'
 flavors:
   - CornFlakes
   - FrootLoops
-swift_declaration_strategy: lazy_var
+swift_declaration_strategy: lazy var
 should_generate_unit_tests: false
 package_manager: cocoapods
 global_secrets:

--- a/spec/fixtures/arkana-empty-environments-fixture.yml
+++ b/spec/fixtures/arkana-empty-environments-fixture.yml
@@ -5,7 +5,7 @@ result_path: 'MySecrets'
 flavors:
   - CornFlakes
   - FrootLoops
-swift_declaration_strategy: lazy_var
+swift_declaration_strategy: lazy var
 should_generate_unit_tests: false
 package_manager: cocoapods
 environments:

--- a/spec/fixtures/arkana-fixture.yml
+++ b/spec/fixtures/arkana-fixture.yml
@@ -5,7 +5,7 @@ result_path: 'MySecrets'
 flavors:
   - CornFlakes
   - FrootLoops
-swift_declaration_strategy: lazy_var
+swift_declaration_strategy: lazy var
 should_generate_unit_tests: false
 package_manager: cocoapods
 environments:

--- a/spec/fixtures/swift-tests.yml
+++ b/spec/fixtures/swift-tests.yml
@@ -2,6 +2,6 @@ import_name: 'MySecrets'
 namespace: 'MySecrets'
 pod_name: 'MySecrets'
 result_path: 'tests'
-swift_declaration_strategy: lazy_var
+swift_declaration_strategy: lazy var
 should_generate_unit_tests: true
 package_manager: spm

--- a/spec/helpers/swift_template_helper_spec.rb
+++ b/spec/helpers/swift_template_helper_spec.rb
@@ -30,4 +30,40 @@ RSpec.describe SwiftTemplateHelper do
       end
     end
   end
+
+  describe ".protocol_getter" do
+    subject { SwiftTemplateHelper.protocol_getter(declaration_strategy) }
+
+    context "when declaration strategy is 'var'" do
+      let(:declaration_strategy) { "var" }
+
+      it "should return 'get'" do
+        expect(subject).to eq "get"
+      end
+    end
+
+    context "when declaration strategy is 'let'" do
+      let(:declaration_strategy) { "let" }
+
+      it "should return 'get'" do
+        expect(subject).to eq "get"
+      end
+    end
+
+    context "when declaration strategy is 'lazy var'" do
+      let(:declaration_strategy) { "lazy var" }
+
+      it "should return 'mutating get'" do
+        expect(subject).to eq "mutating get"
+      end
+    end
+
+    context "when declaration strategy is unknown" do
+      let(:declaration_strategy) { :bananas }
+
+      it "should raise error" do
+        expect { subject }.to raise_error(/Unknown declaration strategy '#{declaration_strategy}' received.'/)
+      end
+    end
+  end
 end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Config do
         expect(subject.pod_name).to eq custom_name
         expect(subject.result_path).to eq custom_name
         expect(subject.flavors).to eq %w[CornFlakes FrootLoops]
-        expect(subject.swift_declaration_strategy).to eq "lazy_var"
+        expect(subject.swift_declaration_strategy).to eq "lazy var"
         expect(subject.should_generate_unit_tests).to be_falsey
         expect(subject.package_manager).to eq "cocoapods"
         expect(subject.current_flavor).to be_nil

--- a/template.yml
+++ b/template.yml
@@ -5,7 +5,7 @@ result_path: 'dependencies' # Optional. Destination path of the generated code, 
 flavors: # Optional. Flavors are keywords added as a prefix to every secret when reading them from environment variables. This is useful for instance in white-label projects. Check the "Usage" section of the README for more information.
   - FrostedFlakes
   - FrootLoops
-swift_declaration_strategy: let # Optional. One of: lazy_var, var, let. Defaults to let.
+swift_declaration_strategy: let # Optional. One of: lazy var, var, let. Defaults to let.
 should_generate_unit_tests: true # Optional. One of: true, false. Defaults to true.
 package_manager: cocoapods # Optional. One of: spm, cocoapods. If you use both, declare cocoapods. Defaults to spm.
 environments: # Optional. List of environments that will be used to generate secret keys when you have keys that are different between environments (e.g. debug/staging/prod). Defaults to empty.


### PR DESCRIPTION
## Description

Prior to this PR:
- It was documented that users should use `lazy_var` instead of `lazy var`, but the latter is what works, actually
- When using `lazy var` as `swift_declaration_strategy`, it would cause compiler issues because the protocol wasn't expecting a mutable getter.
- The main `Package.swift` file would have extra spacing around the test target.