### PR TITLE
Fix Swift compilation issue when using Bool secrets

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task default: %i[spec rubocop]
 
 desc "Generates Swift source code and run its unit tests."
 task :test_swift do
-  sh("bin/arkana --config-filepath spec/fixtures/swift-tests.yml")
+  sh("bin/arkana --config-filepath spec/fixtures/swift-tests.yml --dotenv-filepath spec/fixtures/.env.fruitloops")
   Dir.chdir("tests/MySecrets") do
     sh("swift test")
   end

--- a/lib/arkana/templates/arkana.swift.erb
+++ b/lib/arkana/templates/arkana.swift.erb
@@ -19,6 +19,11 @@ public enum <%= @namespace %> {
             element ^ cipher[offset % cipher.count]
         }, as: UTF8.self)
     }
+
+    static func decode(encoded: [UInt8], cipher: [UInt8]) -> Bool {
+        let stringValue: String = Self.decode(encoded: encoded, cipher: cipher)
+        return Bool(stringValue)!
+    }
 }
 
 public extension <%= @namespace %> {

--- a/lib/arkana/templates/arkana_tests.swift.erb
+++ b/lib/arkana/templates/arkana_tests.swift.erb
@@ -41,4 +41,24 @@ final class <%= @namespace %>Tests: XCTestCase {
         ]
         XCTAssertEqual(<%= @namespace %>.decode(encoded: encoded, cipher: salt), "<%= uuid_key %>")
     }
+
+    func test_decodeTrueBoolValue_shouldDecode() {
+<% bool_key = "true" %>
+<% secret = generate_test_secret(key: bool_key) %>
+        let encoded: [UInt8] = [
+            <%= secret.encoded_value %>
+
+        ]
+        XCTAssertTrue(<%= @namespace %>.decode(encoded: encoded, cipher: salt))
+    }
+
+    func test_decodeFalseBoolValue_shouldDecode() {
+<% bool_key = "false" %>
+<% secret = generate_test_secret(key: bool_key) %>
+        let encoded: [UInt8] = [
+            <%= secret.encoded_value %>
+
+        ]
+        XCTAssertFalse(<%= @namespace %>.decode(encoded: encoded, cipher: salt))
+    }
 }

--- a/spec/fixtures/.env.fruitloops
+++ b/spec/fixtures/.env.fruitloops
@@ -1,1 +1,5 @@
 DOTENV_KEY = "value from flavor dotenv"
+BoolAsStringTrueKey = "true"
+BoolAsStringFalseKey = "false"
+BoolAsBoolTrueKey = true
+BoolAsBoolFalseKey = false

--- a/spec/fixtures/swift-tests.yml
+++ b/spec/fixtures/swift-tests.yml
@@ -5,3 +5,8 @@ result_path: 'tests'
 swift_declaration_strategy: lazy var
 should_generate_unit_tests: true
 package_manager: spm
+global_secrets:
+- BoolAsStringTrueKey
+- BoolAsStringFalseKey
+- BoolAsBoolTrueKey
+- BoolAsBoolFalseKey


### PR DESCRIPTION
## Description

Prior to this PR, if you had an env var of a bool type (i.e. its value is "false" or "true"), then it would generate Bool swift types but it wouldn't compile. This PR fixes this and add tests to cover this case.