### PR TITLE
Add ability to generate secrets only for select environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,14 @@ Usage: `--flavor loremipsum`
 
 Passing a flavor option will change the env var lookup mechanism. Flavors are useful, for instance, when generating secrets for white-label projects.
 
+### `--include-environments`
+
+Usage: `--include-environments dev,staging,prod`
+
+Passing an `--include-environments` option will change the env var lookup mechanism. This option is useful when you want to generate secrets for specific environments only, and skip the verification that checks whether all keys from all environments are present. You might want to use this option to only build debug environments locally (and thus only require debug env vars), and only build staging and production environments in CI (and thus only expose prod env vars to your CI).
+
+Defaults to `nil`, which means all your environments will be used. When passing multiple values, separate them with commas and no spaces.
+
 #### Example
 
 Let's load a flavor called `snowflakes` and load a secret called `MySecretAPIKey`:

--- a/Rakefile
+++ b/Rakefile
@@ -14,7 +14,7 @@ task default: %i[spec rubocop]
 
 desc "Generates Swift source code and run its unit tests."
 task :test_swift do
-  sh("ARKANA_RUNNING_CI_INTEGRATION_TESTS=true bin/arkana --config-filepath spec/fixtures/swift-tests.yml --dotenv-filepath spec/fixtures/.env.fruitloops")
+  sh("ARKANA_RUNNING_CI_INTEGRATION_TESTS=true bin/arkana --config-filepath spec/fixtures/swift-tests.yml --dotenv-filepath spec/fixtures/.env.fruitloops --include-environments dev,staging")
   Dir.chdir("tests/MySecrets") do
     sh("swift test")
   end

--- a/lib/arkana/config_parser.rb
+++ b/lib/arkana/config_parser.rb
@@ -12,6 +12,7 @@ module ConfigParser
   def self.parse(arguments)
     yaml = YAML.load_file(arguments.config_filepath)
     config = Config.new(yaml)
+    config.include_environments(arguments.include_environments)
     config.current_flavor = arguments.flavor
     config.dotenv_filepath = arguments.dotenv_filepath
     UI.warn("Dotenv file was specified but couldn't be found at '#{config.dotenv_filepath}'") if config.dotenv_filepath && !File.exist?(config.dotenv_filepath)

--- a/lib/arkana/models/arguments.rb
+++ b/lib/arkana/models/arguments.rb
@@ -10,12 +10,15 @@ class Arguments
   attr_reader :dotenv_filepath
   # @returns [string]
   attr_reader :flavor
+  # @returns [Array<string>]
+  attr_reader :include_environments
 
   def initialize
     # Default values
     @config_filepath = ".arkana.yml"
     @dotenv_filepath = ".env" if File.exist?(".env")
     @flavor = nil
+    @include_environments = nil
 
     OptionParser.new do |opt|
       opt.on("-c", "--config-filepath /path/to/your/.arkana.yml", "Path to your config file. Defaults to '.arkana.yml'") do |o|
@@ -26,6 +29,9 @@ class Arguments
       end
       opt.on("-f", "--flavor FrostedFlakes", "Flavors are useful, for instance, when generating secrets for white-label projects. See the README for more information") do |o|
         @flavor = o
+      end
+      opt.on("--include-environments debug,release", "Optionally pass the environments that you want Arkana to generate secrets for. Useful if you only want to build a certain environment, e.g. just Debug in local machines, while only building Staging and Release in CI. Separate the keys using a comma, without spaces. When ommitted, Arkana generate secrets for all environments.") do |o|
+        @include_environments = o.split(",")
       end
     end.parse!
   end

--- a/lib/arkana/models/config.rb
+++ b/lib/arkana/models/config.rb
@@ -63,4 +63,9 @@ class Config
   def all_keys
     global_secrets + environment_keys
   end
+
+  def include_environments(environments)
+    return unless environments
+    @environments = @environments.select { |e| environments.map(&:downcase).include?(e.downcase) }
+  end
 end

--- a/spec/arkana_spec.rb
+++ b/spec/arkana_spec.rb
@@ -25,5 +25,24 @@ RSpec.describe Arkana do
         Arkana.run(arguments)
       end
     end
+
+    context "when only a subset of environments is included" do
+      before do
+        ARGV.replace([
+          "--config-filepath", config_filepath,
+          "--include-environments", "debug,release,debugPlusMore",
+        ])
+
+        config.all_keys.each do |key|
+          allow(ENV).to receive(:[]).with(key).and_return("lorem ipsum")
+        end
+        allow(ENV).to receive(:[]).with("ServiceKeyReleasePlusMore").and_return(nil)
+        allow(ENV).to receive(:[]).with("ServerReleasePlusMore").and_return(nil)
+      end
+
+      it "should not error out when it cant find a missing env var that wasnt included in the list of environments" do
+        expect { Arkana.run(arguments) }.to_not raise_error
+      end
+    end
   end
 end

--- a/spec/config_parser_spec.rb
+++ b/spec/config_parser_spec.rb
@@ -81,5 +81,23 @@ RSpec.describe ConfigParser do
         end
       end
     end
+
+    describe "#include_environments" do
+      describe "when include_environments is specified" do
+        let(:include_environments) { ["debug", "debugPlusMore"] }
+        before { ARGV << "--include-environments" << include_environments.join(",") }
+
+        it "should include the environments specified, case insensitive" do
+          expect(subject.environments.map(&:downcase)).to match_array(include_environments.map(&:downcase))
+        end
+      end
+
+      describe "when include_environments is not specified" do
+        it "should include all environments" do
+          all_environments = ["debug", "release", "debugPlusMore", "ReleasePlusMore"]
+          expect(subject.environments.map(&:downcase)).to match_array(all_environments.map(&:downcase))
+        end
+      end
+    end
   end
 end

--- a/spec/fixtures/.env.fruitloops
+++ b/spec/fixtures/.env.fruitloops
@@ -11,3 +11,7 @@ SecretWithDollarSignNotEscapedAndSingleQuoteKey = 'real_$lim_shady'
 SecretWithDollarSignNotEscapedAndDoubleQuotesKey = "real_$lim_shady"
 SecretWithDollarSignNotEscapedAndNoQuotesKey = real_$lim_shady
 SecretWithWeirdCharactersKey = "` ~ ! @ # % ^ & * ( ) _ - + = { [ } } | : ; ' < , > . ? /"
+ServiceKeyDev = "this dev key is secret"
+ServerDev = "dev.example.com"
+ServiceKeyStaging = "this staging key is secret"
+ServerStaging = "staging.example.com"

--- a/spec/fixtures/swift-tests.yml
+++ b/spec/fixtures/swift-tests.yml
@@ -18,3 +18,10 @@ global_secrets:
 - SecretWithDollarSignNotEscapedAndDoubleQuotesKey
 - SecretWithDollarSignNotEscapedAndNoQuotesKey
 - SecretWithWeirdCharactersKey
+environments:
+  - dev
+  - staging
+  - prod
+environment_secrets:
+  - ServiceKey
+  - Server

--- a/spec/models/arguments_spec.rb
+++ b/spec/models/arguments_spec.rb
@@ -66,4 +66,21 @@ RSpec.describe Arguments do
       end
     end
   end
+
+  describe "#environments" do
+    context "when the option is ommitted in ARGV" do
+      it "should default to nil" do
+        expect(subject.include_environments).to be_nil
+      end
+    end
+
+    context "when the option is passed in ARGV" do
+      let(:expected_environments) { ["first_env", "second_env"] }
+      before { ARGV.replace(["--include-environments", expected_environments.join(",")]) }
+
+      it "should return the environments passed as an array, not as a comma-separated string" do
+        expect(subject.include_environments).to eq expected_environments
+      end
+    end
+  end
 end

--- a/spec/models/config_spec.rb
+++ b/spec/models/config_spec.rb
@@ -44,6 +44,14 @@ RSpec.describe Config do
         expect(subject.dotenv_filepath).to be_nil
       end
     end
+
+    context "when all_keys is empty" do
+      subject { Config.new({}) }
+
+      it "should raise an error" do
+        expect { SwiftCodeGenerator.generate(template_arguments: template_arguments, config: config) }.to raise_error(StandardError)
+      end
+    end
   end
 
   describe `#environment_keys` do
@@ -78,6 +86,43 @@ RSpec.describe Config do
             subject.environments.any? { |env| key.end_with?(env) }
           end).to be_truthy
         end
+      end
+    end
+  end
+
+  describe ".include_environments" do
+    context "when nil is passed" do
+      it "should include all environments declared in the yaml file" do
+        subject.include_environments(nil)
+        expect(subject.environments).to match_array %w[Debug Release DebugPlusMore ReleasePlusMore]
+      end
+    end
+
+    context "when 1 environment is passed" do
+      it "should only that environment in the environments" do
+        subject.include_environments(["DebugPlusMore"])
+        expect(subject.environments).to match_array %w[DebugPlusMore]
+      end
+    end
+
+    context "when all environments are passed" do
+      it "should only that environment in the environments" do
+        subject.include_environments(%w[Debug Release DebugPlusMore ReleasePlusMore])
+        expect(subject.environments).to match_array %w[Debug Release DebugPlusMore ReleasePlusMore]
+      end
+    end
+
+    context "when an empty array is passed" do
+      it "should cause the subject's environments to become empty" do
+        subject.include_environments([])
+        expect(subject.environments).to be_empty
+      end
+    end
+
+    context "when a string that is not an environment is passed" do
+      it "should ignore that string and consider the other elements of the array passed, if any" do
+        subject.include_environments(["I double dare you"])
+        expect(subject.environments).to be_empty
       end
     end
   end


### PR DESCRIPTION
## Description

Resolves #31

## Testing

To test this branch, modify your Gemfile as:

```ruby
gem 'arkana', git: 'https://github.com/rogerluan/arkana.git', branch: 'roger/select-environments'
```

And run `bundle install` to apply the changes.

Then follow the documentation in the README (you can read the diff in this PR) to generate secrets only for select environments.