### PR TITLE
Fix CI after Code Climate stopped supporting code coverage collection on macOS

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,20 @@
+name: Generate & Upload Code Coverage
+on:
+  push:
+    branches:
+      - main
+jobs:
+  test:
+    env:
+      CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: head
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - uses: paambaati/codeclimate-action@v6.0.0
+      with:
+        coverageCommand: bundle exec rake
+        debug: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['2.7', '3.0', '3.1', head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,5 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - uses: paambaati/codeclimate-action@v6.0.0
-      with:
-        coverageCommand: bundle exec rake
-        debug: true
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
-        ruby: ['2.7', '3.0', '3.1', head]
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3', head]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
## Description

In this PR I:

- Moved the code coverage collection/upload step to be run just once and just from a linux machine.
- Changed test runs so that they run but don't upload code coverage results on every env.
- Added a few more Ruby versions to test this on.